### PR TITLE
[fix] Replacing Glob validation for Regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ $ ./codeowners-verifier help verify
 
 Verify must receive a path as argument. It then checks if the given path is covered by any of the existing entries.
 
+:warning: This runs against the relative path of the git repository
+
 Example:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ FATA[0000] Missing CODEOWNER entry, matched rule from line 7 don't have valid ow
 
 ### Validate
 
-Validate validates the entire CODEOWNERS file, checking if the users and/or groups are valid. It does that by checking if the user or group is validy on the provider API.
+Validate validates the entire CODEOWNERS file, checking if the users and/or groups are valid. It does that by checking if the user or group is valid on the provider API.
 
 It must receive the name of the provider. YOu can check for the available providers by executing the help:
 

--- a/pkg/verifier/codeowner.go
+++ b/pkg/verifier/codeowner.go
@@ -4,11 +4,10 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"unicode"
-
-	glob "gopkg.in/godo.v2/glob"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/topfreegames/codeowners-verifier/pkg/providers"
@@ -102,8 +101,16 @@ func ValidateCodeownerFile(p providers.Provider, filename string) (bool, error) 
 	}
 	valid := true
 	for _, c := range codeowners {
-		// This doesn't works for ! patterns
-		if files, _, err := glob.Glob([]string{c.Path}); err != nil || len(files) < 1 {
+		currentDir, _ := os.Getwd()
+		files, _ := FilePathWalkDir(currentDir)
+		fileMatches := false
+		for _, file := range files {
+			if c.MatchesPath(strings.Replace(file, currentDir, "", 1)) {
+				fileMatches = true
+				break
+			}
+		}
+		if !fileMatches {
 			log.Errorf("Error parsing line %d, path %s does not exist", c.Line, c.Path)
 			valid = false
 		}
@@ -127,7 +134,7 @@ func ValidateCodeownerFile(p providers.Provider, filename string) (bool, error) 
 }
 
 // getPatternFromLine converts a line to a CODEOWNERS entry
-// This is roughly addapted from https://github.com/sabhiram/go-gitignore
+// This is roughly adapted from https://github.com/sabhiram/go-gitignore
 func getPatternFromLine(line string) (*regexp.Regexp, bool) {
 	// Trim OS-specific carriage returns.
 	line = strings.TrimRight(line, "\r")
@@ -181,6 +188,17 @@ func getPatternFromLine(line string) (*regexp.Regexp, bool) {
 	pattern, _ := regexp.Compile(expr)
 
 	return pattern, negatePattern
+}
+
+func FilePathWalkDir(root string) ([]string, error) {
+	var files []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if !info.IsDir() {
+			files = append(files, path)
+		}
+		return nil
+	})
+	return files, err
 }
 
 // MatchesPath returns true if the given GitIgnore structure would target

--- a/pkg/verifier/codeowner.go
+++ b/pkg/verifier/codeowner.go
@@ -105,6 +105,7 @@ func ValidateCodeownerFile(p providers.Provider, filename string) (bool, error) 
 		files, _ := FilePathWalkDir(currentDir)
 		fileMatches := false
 		for _, file := range files {
+
 			if c.MatchesPath(strings.Replace(file, currentDir, "", 1)) {
 				fileMatches = true
 				break
@@ -198,6 +199,9 @@ func FilePathWalkDir(root string) ([]string, error) {
 		}
 		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
 	return files, err
 }
 

--- a/pkg/verifier/codeowner.go
+++ b/pkg/verifier/codeowner.go
@@ -104,12 +104,10 @@ func ValidateCodeownerFile(p providers.Provider, filename string) (bool, error) 
 		currentDir, _ := os.Getwd()
 		files, _ := FilePathWalkDir(currentDir)
 		fileMatches := false
-		for _, file := range files {
-
-			if c.MatchesPath(strings.Replace(file, currentDir, "", 1)) {
-				fileMatches = true
-				break
-			}
+		for idx := 0; idx < len(files) && !fileMatches; idx++ {
+			// remove current dir from filepath to use regex properly.
+			file := strings.Replace(files[idx], currentDir, "", 1)
+			fileMatches = c.MatchesPath(file)
 		}
 		if !fileMatches {
 			log.Errorf("Error parsing line %d, path %s does not exist", c.Line, c.Path)

--- a/pkg/verifier/codeowner_test.go
+++ b/pkg/verifier/codeowner_test.go
@@ -495,6 +495,9 @@ func TestValidateCodeownerFileGitlab(t *testing.T) {
 			Name: "Correct CodeOwners File",
 			Sample: map[string]interface{}{
 				"CodeOwners": filet.TmpFile(t, "", `* @user1
+/*.* @user1
+/**/* @user1
+/`+folder1+`/** @user1
 `+folder1+` @user2 @group1
 `+folder1+`/* @user3
 `+folder2+`/** @group1

--- a/pkg/verifier/codeowner_test.go
+++ b/pkg/verifier/codeowner_test.go
@@ -466,13 +466,13 @@ func TestValidateCodeownerFileGitlab(t *testing.T) {
 		./folder2/folder3/file3
 		./file4
 	*/
-	folder1 := filet.TmpDir(t, "")
-	folder2 := filet.TmpDir(t, "")
-	folder3 := filet.TmpDir(t, folder2)
+	folder1 := filet.TmpDir(t, "./")
+	folder2 := filet.TmpDir(t, "./")
+	folder3 := filet.TmpDir(t, "./"+folder2)
 	filet.TmpFile(t, folder1, "")
 	filet.TmpFile(t, folder2, "")
 	file1 := filet.TmpFile(t, folder3, "").Name()
-	filet.TmpFile(t, "", "")
+	filet.TmpFile(t, "./", "")
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	MockGitlabClient := providers.NewMockClientInterface(mockCtrl)

--- a/pkg/verifier/codeowner_test.go
+++ b/pkg/verifier/codeowner_test.go
@@ -1,6 +1,7 @@
 package verifier
 
 import (
+	"path/filepath"
 	"regexp"
 	"testing"
 
@@ -468,7 +469,7 @@ func TestValidateCodeownerFileGitlab(t *testing.T) {
 	*/
 	folder1 := filet.TmpDir(t, "./")
 	folder2 := filet.TmpDir(t, "./")
-	folder3 := filet.TmpDir(t, "./"+folder2)
+	folder3 := filet.TmpDir(t, filepath.Join("./", folder2))
 	filet.TmpFile(t, folder1, "")
 	filet.TmpFile(t, folder2, "")
 	file1 := filet.TmpFile(t, folder3, "").Name()


### PR DESCRIPTION
The lib we used for validating if a declared path existed wasn't covering every single case.

This fixes https://github.com/topfreegames/codeowners-verifier/issues/6